### PR TITLE
Allow interchangeability of KANLinear with nn.Linear

### DIFF
--- a/src/efficient_kan/kan.py
+++ b/src/efficient_kan/kan.py
@@ -151,14 +151,19 @@ class KANLinear(torch.nn.Module):
         )
 
     def forward(self, x: torch.Tensor):
-        assert x.dim() == 2 and x.size(1) == self.in_features
+        assert x.size(-1) == self.in_features
+        original_shape = x.shape
+        x = x.view(-1, self.in_features)
 
         base_output = F.linear(self.base_activation(x), self.base_weight)
         spline_output = F.linear(
             self.b_splines(x).view(x.size(0), -1),
             self.scaled_spline_weight.view(self.out_features, -1),
         )
-        return base_output + spline_output
+        output = base_output + spline_output
+        
+        output = output.view(*original_shape[:-1], self.out_features)
+        return output
 
     @torch.no_grad()
     def update_grid(self, x: torch.Tensor, margin=0.01):


### PR DESCRIPTION
Currently KANLinear strictly checks the dimensions are (batch_size, in_features). This does not allow compatibility with other input shapes where the feature sizes of the same. On the other hand, nn.Linear allows for any shape where the last dimension matches feature shape, eg: (*, in_features), and it will reshape it to match and reshape back to the same (*, out_features) on returning. Because of this difference, KANLinear and nn.Linear are currently not interchangeable, prevent people from swapping MLPs with KANs in existing code to explore differences in the two.

This change would allow for better shape compatibility, and therefore allow people to interchange KANLinear (or KAN) with nn.Linear layers.