### PR TITLE
refactor: utilize Einops in appropriate areas to enhance readability

### DIFF
--- a/src/efficient_kan/kan.py
+++ b/src/efficient_kan/kan.py
@@ -209,10 +209,8 @@ class KANLinear(torch.nn.Module):
         """
         l1_fake = reduce(self.spline_weight, '... -> ...', 'abs').mean(-1)
         regularization_loss_activation = l1_fake.sum()
-
         p = l1_fake / regularization_loss_activation
         regularization_loss_entropy = -torch.sum(p * p.log())
-
         return (
             regularize_activation * regularization_loss_activation
             + regularize_entropy * regularization_loss_entropy
@@ -265,4 +263,3 @@ class KAN(torch.nn.Module):
             layer.regularization_loss(regularize_activation, regularize_entropy)
             for layer in self.layers
         )
-    

--- a/src/efficient_kan/kan.py
+++ b/src/efficient_kan/kan.py
@@ -6,19 +6,19 @@ import math
 class KANLinear(torch.nn.Module):
     def __init__(
         self,
-        in_features,
-        out_features,
-        grid_size=5,
-        spline_order=3,
-        scale_noise=0.1,
-        scale_base=1.0,
-        scale_spline=1.0,
-        enable_standalone_scale_spline=True,
-        base_activation=torch.nn.SiLU,
-        grid_eps=0.02,
-        grid_range=[-1, 1],
+        in_features: int,
+        out_features: int,
+        grid_size: int = 5,
+        spline_order: int = 3,
+        scale_noise: float = 0.1,
+        scale_base: float = 1.0,
+        scale_spline: float = 1.0,
+        enable_standalone_scale_spline: bool = True,
+        base_activation: torch.nn.Module = torch.nn.SiLU,
+        grid_eps: float = 0.02,
+        grid_range: list = [-1, 1],
     ):
-        super(KANLinear, self).__init__()
+        super().__init__()
         self.in_features = in_features
         self.out_features = out_features
         self.grid_size = grid_size
@@ -39,10 +39,9 @@ class KANLinear(torch.nn.Module):
         self.spline_weight = torch.nn.Parameter(
             torch.Tensor(out_features, in_features, grid_size + spline_order)
         )
-        if enable_standalone_scale_spline:
-            self.spline_scaler = torch.nn.Parameter(
-                torch.Tensor(out_features, in_features)
-            )
+        self.spline_scaler = torch.nn.Parameter(
+            torch.Tensor(out_features, in_features)
+        ) if enable_standalone_scale_spline else None
 
         self.scale_noise = scale_noise
         self.scale_base = scale_base
@@ -59,81 +58,51 @@ class KANLinear(torch.nn.Module):
             noise = (
                 (
                     torch.rand(self.grid_size + 1, self.in_features, self.out_features)
-                    - 1 / 2
+                    - 0.5
                 )
                 * self.scale_noise
                 / self.grid_size
             )
+            spline_weight = self.curve2coeff(
+                self.grid.T[self.spline_order : -self.spline_order],
+                noise,
+            )
             self.spline_weight.data.copy_(
-                (self.scale_spline if not self.enable_standalone_scale_spline else 1.0)
-                * self.curve2coeff(
-                    self.grid.T[self.spline_order : -self.spline_order],
-                    noise,
-                )
+                self.scale_spline * spline_weight if not self.enable_standalone_scale_spline else spline_weight
             )
             if self.enable_standalone_scale_spline:
-                # torch.nn.init.constant_(self.spline_scaler, self.scale_spline)
                 torch.nn.init.kaiming_uniform_(self.spline_scaler, a=math.sqrt(5) * self.scale_spline)
 
-    def b_splines(self, x: torch.Tensor):
-        """
-        Compute the B-spline bases for the given input tensor.
-
-        Args:
-            x (torch.Tensor): Input tensor of shape (batch_size, in_features).
-
-        Returns:
-            torch.Tensor: B-spline bases tensor of shape (batch_size, in_features, grid_size + spline_order).
-        """
+    def b_splines(self, x: torch.Tensor) -> torch.Tensor:
         assert x.dim() == 2 and x.size(1) == self.in_features
 
-        grid: torch.Tensor = (
-            self.grid
-        )  # (in_features, grid_size + 2 * spline_order + 1)
+        grid: torch.Tensor = self.grid
         x = x.unsqueeze(-1)
-        bases = ((x >= grid[:, :-1]) & (x < grid[:, 1:])).to(x.dtype)
-        for k in range(1, self.spline_order + 1):
-            bases = (
-                (x - grid[:, : -(k + 1)])
-                / (grid[:, k:-1] - grid[:, : -(k + 1)])
-                * bases[:, :, :-1]
-            ) + (
-                (grid[:, k + 1 :] - x)
-                / (grid[:, k + 1 :] - grid[:, 1:(-k)])
-                * bases[:, :, 1:]
-            )
+        bases = ((x >= grid[:, :-1]) & (x < grid[:, 1:])).float()
 
+        for k in range(1, self.spline_order + 1):
+            diff1 = grid[:, k:-1] - grid[:, :-(k + 1)]
+            diff2 = grid[:, k+1:] - grid[:, 1:-k]
+
+            bases = (x - grid[:, :-(k + 1)]) / diff1 * bases[:, :, :-1] + \
+                    (grid[:, k + 1:] - x) / diff2 * bases[:, :, 1:]
+        
         assert bases.size() == (
             x.size(0),
             self.in_features,
             self.grid_size + self.spline_order,
         )
+
         return bases.contiguous()
 
-    def curve2coeff(self, x: torch.Tensor, y: torch.Tensor):
-        """
-        Compute the coefficients of the curve that interpolates the given points.
-
-        Args:
-            x (torch.Tensor): Input tensor of shape (batch_size, in_features).
-            y (torch.Tensor): Output tensor of shape (batch_size, in_features, out_features).
-
-        Returns:
-            torch.Tensor: Coefficients tensor of shape (out_features, in_features, grid_size + spline_order).
-        """
+    def curve2coeff(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         assert x.dim() == 2 and x.size(1) == self.in_features
         assert y.size() == (x.size(0), self.in_features, self.out_features)
 
-        A = self.b_splines(x).transpose(
-            0, 1
-        )  # (in_features, batch_size, grid_size + spline_order)
-        B = y.transpose(0, 1)  # (in_features, batch_size, out_features)
-        solution = torch.linalg.lstsq(
-            A, B
-        ).solution  # (in_features, grid_size + spline_order, out_features)
-        result = solution.permute(
-            2, 0, 1
-        )  # (out_features, in_features, grid_size + spline_order)
+        A = self.b_splines(x).transpose(0, 1)
+        B = y.transpose(0, 1)
+        solution = torch.linalg.lstsq(A, B).solution
+        result = solution.permute(2, 0, 1)
 
         assert result.size() == (
             self.out_features,
@@ -143,14 +112,12 @@ class KANLinear(torch.nn.Module):
         return result.contiguous()
 
     @property
-    def scaled_spline_weight(self):
-        return self.spline_weight * (
-            self.spline_scaler.unsqueeze(-1)
-            if self.enable_standalone_scale_spline
-            else 1.0
-        )
+    def scaled_spline_weight(self) -> torch.Tensor:
+        if self.enable_standalone_scale_spline:
+            return self.spline_weight * self.spline_scaler.unsqueeze(-1)
+        return self.spline_weight
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         assert x.size(-1) == self.in_features
         original_shape = x.shape
         x = x.view(-1, self.in_features)
@@ -166,67 +133,38 @@ class KANLinear(torch.nn.Module):
         return output
 
     @torch.no_grad()
-    def update_grid(self, x: torch.Tensor, margin=0.01):
-        assert x.dim() == 2 and x.size(1) == self.in_features
-        batch = x.size(0)
+    def update_grid(self, x: torch.Tensor, margin: float = 0.01):
+        assert x.dim() == 2 and x.size(1) == self.in_features, "Input tensor must be 2D with correct feature size."
+    
+        batch_size = x.size(0)
+    
+        splines = self.b_splines(x).permute(1, 0, 2)
+        orig_coeff = self.scaled_spline_weight.permute(1, 2, 0)
+        unreduced_spline_output = torch.bmm(splines, orig_coeff).permute(1, 0, 2)
 
-        splines = self.b_splines(x)  # (batch, in, coeff)
-        splines = splines.permute(1, 0, 2)  # (in, batch, coeff)
-        orig_coeff = self.scaled_spline_weight  # (out, in, coeff)
-        orig_coeff = orig_coeff.permute(1, 2, 0)  # (in, coeff, out)
-        unreduced_spline_output = torch.bmm(splines, orig_coeff)  # (in, batch, out)
-        unreduced_spline_output = unreduced_spline_output.permute(
-            1, 0, 2
-        )  # (batch, in, out)
-
-        # sort each channel individually to collect data distribution
         x_sorted = torch.sort(x, dim=0)[0]
-        grid_adaptive = x_sorted[
-            torch.linspace(
-                0, batch - 1, self.grid_size + 1, dtype=torch.int64, device=x.device
-            )
-        ]
-
+        indices = torch.linspace(0, batch_size - 1, self.grid_size + 1, dtype=torch.int64, device=x.device)
+        grid_adaptive = x_sorted[indices]
+    
         uniform_step = (x_sorted[-1] - x_sorted[0] + 2 * margin) / self.grid_size
         grid_uniform = (
-            torch.arange(
-                self.grid_size + 1, dtype=torch.float32, device=x.device
-            ).unsqueeze(1)
+            torch.arange(self.grid_size + 1, dtype=torch.float32, device=x.device).unsqueeze(1)
             * uniform_step
             + x_sorted[0]
             - margin
         )
-
+    
         grid = self.grid_eps * grid_uniform + (1 - self.grid_eps) * grid_adaptive
-        grid = torch.concatenate(
-            [
-                grid[:1]
-                - uniform_step
-                * torch.arange(self.spline_order, 0, -1, device=x.device).unsqueeze(1),
-                grid,
-                grid[-1:]
-                + uniform_step
-                * torch.arange(1, self.spline_order + 1, device=x.device).unsqueeze(1),
-            ],
-            dim=0,
-        )
-
+    
+        lower_bound = grid[:1] - uniform_step * torch.arange(self.spline_order, 0, -1, device=x.device).unsqueeze(1)
+        upper_bound = grid[-1:] + uniform_step * torch.arange(1, self.spline_order + 1, device=x.device).unsqueeze(1)
+        grid = torch.cat([lower_bound, grid, upper_bound], dim=0)
+    
+        # Update grid and spline weights in the class
         self.grid.copy_(grid.T)
         self.spline_weight.data.copy_(self.curve2coeff(x, unreduced_spline_output))
 
-    def regularization_loss(self, regularize_activation=1.0, regularize_entropy=1.0):
-        """
-        Compute the regularization loss.
-
-        This is a dumb simulation of the original L1 regularization as stated in the
-        paper, since the original one requires computing absolutes and entropy from the
-        expanded (batch, in_features, out_features) intermediate tensor, which is hidden
-        behind the F.linear function if we want an memory efficient implementation.
-
-        The L1 regularization is now computed as mean absolute value of the spline
-        weights. The authors implementation also includes this term in addition to the
-        sample-based regularization.
-        """
+    def regularization_loss(self, regularize_activation: float = 1.0, regularize_entropy: float = 1.0) -> torch.Tensor:
         l1_fake = self.spline_weight.abs().mean(-1)
         regularization_loss_activation = l1_fake.sum()
         p = l1_fake / regularization_loss_activation
@@ -240,45 +178,43 @@ class KANLinear(torch.nn.Module):
 class KAN(torch.nn.Module):
     def __init__(
         self,
-        layers_hidden,
-        grid_size=5,
-        spline_order=3,
-        scale_noise=0.1,
-        scale_base=1.0,
-        scale_spline=1.0,
-        base_activation=torch.nn.SiLU,
-        grid_eps=0.02,
-        grid_range=[-1, 1],
+        layers_hidden: list,
+        grid_size: int = 5,
+        spline_order: int = 3,
+        scale_noise: float = 0.1,
+        scale_base: float = 1.0,
+        scale_spline: float = 1.0,
+        base_activation: torch.nn.Module = torch.nn.SiLU,
+        grid_eps: float = 0.02,
+        grid_range: list = [-1, 1],
     ):
-        super(KAN, self).__init__()
+        super().__init__()
         self.grid_size = grid_size
         self.spline_order = spline_order
 
-        self.layers = torch.nn.ModuleList()
-        for in_features, out_features in zip(layers_hidden, layers_hidden[1:]):
-            self.layers.append(
-                KANLinear(
-                    in_features,
-                    out_features,
-                    grid_size=grid_size,
-                    spline_order=spline_order,
-                    scale_noise=scale_noise,
-                    scale_base=scale_base,
-                    scale_spline=scale_spline,
-                    base_activation=base_activation,
-                    grid_eps=grid_eps,
-                    grid_range=grid_range,
-                )
+        self.layers = torch.nn.ModuleList([
+            KANLinear(
+                in_features, out_features,
+                grid_size=grid_size,
+                spline_order=spline_order,
+                scale_noise=scale_noise,
+                scale_base=scale_base,
+                scale_spline=scale_spline,
+                base_activation=base_activation,
+                grid_eps=grid_eps,
+                grid_range=grid_range,
             )
+            for in_features, out_features in zip(layers_hidden, layers_hidden[1:])
+        ])
 
-    def forward(self, x: torch.Tensor, update_grid=False):
+    def forward(self, x: torch.Tensor, update_grid: bool = False) -> torch.Tensor:
         for layer in self.layers:
             if update_grid:
                 layer.update_grid(x)
             x = layer(x)
         return x
 
-    def regularization_loss(self, regularize_activation=1.0, regularize_entropy=1.0):
+    def regularization_loss(self, regularize_activation: float = 1.0, regularize_entropy: float = 1.0) -> torch.Tensor:
         return sum(
             layer.regularization_loss(regularize_activation, regularize_entropy)
             for layer in self.layers

--- a/src/efficient_kan/kan.py
+++ b/src/efficient_kan/kan.py
@@ -104,8 +104,6 @@ class KANLinear(torch.nn.Module):
         )
         return bases.contiguous()
 
-    from einops import rearrange
-
     def curve2coeff(self, x: torch.Tensor, y: torch.Tensor):
         """
         Compute the coefficients of the curve that interpolates the given points.
@@ -209,15 +207,12 @@ class KANLinear(torch.nn.Module):
         weights. The authors implementation also includes this term in addition to the
         sample-based regularization.
         """
-        # Compute L1 regularization term using einops
         l1_fake = reduce(self.spline_weight, '... -> ...', 'abs').mean(-1)
         regularization_loss_activation = l1_fake.sum()
 
-        # Compute entropy regularization term
         p = l1_fake / regularization_loss_activation
         regularization_loss_entropy = -torch.sum(p * p.log())
 
-        # Combine the regularization terms
         return (
             regularize_activation * regularization_loss_activation
             + regularize_entropy * regularization_loss_entropy

--- a/src/efficient_kan/kan.py
+++ b/src/efficient_kan/kan.py
@@ -1,24 +1,24 @@
 import torch
 import torch.nn.functional as F
 import math
-
+from einops import rearrange, repeat, reduce
 
 class KANLinear(torch.nn.Module):
     def __init__(
         self,
-        in_features: int,
-        out_features: int,
-        grid_size: int = 5,
-        spline_order: int = 3,
-        scale_noise: float = 0.1,
-        scale_base: float = 1.0,
-        scale_spline: float = 1.0,
-        enable_standalone_scale_spline: bool = True,
-        base_activation: torch.nn.Module = torch.nn.SiLU,
-        grid_eps: float = 0.02,
-        grid_range: list = [-1, 1],
+        in_features,
+        out_features,
+        grid_size=5,
+        spline_order=3,
+        scale_noise=0.1,
+        scale_base=1.0,
+        scale_spline=1.0,
+        enable_standalone_scale_spline=True,
+        base_activation=torch.nn.SiLU,
+        grid_eps=0.02,
+        grid_range=[-1, 1],
     ):
-        super().__init__()
+        super(KANLinear, self).__init__()
         self.in_features = in_features
         self.out_features = out_features
         self.grid_size = grid_size
@@ -39,9 +39,10 @@ class KANLinear(torch.nn.Module):
         self.spline_weight = torch.nn.Parameter(
             torch.Tensor(out_features, in_features, grid_size + spline_order)
         )
-        self.spline_scaler = torch.nn.Parameter(
-            torch.Tensor(out_features, in_features)
-        ) if enable_standalone_scale_spline else None
+        if enable_standalone_scale_spline:
+            self.spline_scaler = torch.nn.Parameter(
+                torch.Tensor(out_features, in_features)
+            )
 
         self.scale_noise = scale_noise
         self.scale_base = scale_base
@@ -58,51 +59,74 @@ class KANLinear(torch.nn.Module):
             noise = (
                 (
                     torch.rand(self.grid_size + 1, self.in_features, self.out_features)
-                    - 0.5
+                    - 1 / 2
                 )
                 * self.scale_noise
                 / self.grid_size
             )
-            spline_weight = self.curve2coeff(
-                self.grid.T[self.spline_order : -self.spline_order],
-                noise,
-            )
             self.spline_weight.data.copy_(
-                self.scale_spline * spline_weight if not self.enable_standalone_scale_spline else spline_weight
+                (self.scale_spline if not self.enable_standalone_scale_spline else 1.0)
+                * self.curve2coeff(
+                    self.grid.T[self.spline_order : -self.spline_order],
+                    noise,
+                )
             )
             if self.enable_standalone_scale_spline:
+                # torch.nn.init.constant_(self.spline_scaler, self.scale_spline)
                 torch.nn.init.kaiming_uniform_(self.spline_scaler, a=math.sqrt(5) * self.scale_spline)
 
-    def b_splines(self, x: torch.Tensor) -> torch.Tensor:
+    def b_splines(self, x: torch.Tensor):
+        """
+        Compute the B-spline bases for the given input tensor.
+
+        Args:
+            x (torch.Tensor): Input tensor of shape (batch_size, in_features).
+
+        Returns:
+            torch.Tensor: B-spline bases tensor of shape (batch_size, in_features, grid_size + spline_order).
+         """
         assert x.dim() == 2 and x.size(1) == self.in_features
 
-        grid: torch.Tensor = self.grid
-        x = x.unsqueeze(-1)
-        bases = ((x >= grid[:, :-1]) & (x < grid[:, 1:])).float()
+        grid: torch.Tensor = self.grid  # (in_features, grid_size + 2 * spline_order + 1)
+        x = rearrange(x, 'b f -> b f 1')
+        bases = (x >= grid[:, :-1]) & (x < grid[:, 1:])
+        bases = bases.to(x.dtype)
 
         for k in range(1, self.spline_order + 1):
-            diff1 = grid[:, k:-1] - grid[:, :-(k + 1)]
-            diff2 = grid[:, k+1:] - grid[:, 1:-k]
+            left = (x - grid[:, :-(k + 1)]) / (grid[:, k:-1] - grid[:, :-(k + 1)])
+            right = (grid[:, k + 1:] - x) / (grid[:, k + 1:] - grid[:, 1:(-k)])
+            bases = left * bases[:, :, :-1] + right * bases[:, :, 1:]
 
-            bases = (x - grid[:, :-(k + 1)]) / diff1 * bases[:, :, :-1] + \
-                    (grid[:, k + 1:] - x) / diff2 * bases[:, :, 1:]
-        
         assert bases.size() == (
             x.size(0),
             self.in_features,
             self.grid_size + self.spline_order,
         )
-
         return bases.contiguous()
 
-    def curve2coeff(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    from einops import rearrange
+
+    def curve2coeff(self, x: torch.Tensor, y: torch.Tensor):
+        """
+        Compute the coefficients of the curve that interpolates the given points.
+
+         Args:
+            x (torch.Tensor): Input tensor of shape (batch_size, in_features).
+            y (torch.Tensor): Output tensor of shape (batch_size, in_features, out_features).
+
+        Returns:
+            torch.Tensor: Coefficients tensor of shape (out_features, in_features, grid_size + spline_order).
+        """
         assert x.dim() == 2 and x.size(1) == self.in_features
         assert y.size() == (x.size(0), self.in_features, self.out_features)
 
-        A = self.b_splines(x).transpose(0, 1)
-        B = y.transpose(0, 1)
-        solution = torch.linalg.lstsq(A, B).solution
-        result = solution.permute(2, 0, 1)
+        A = self.b_splines(x)  # (batch_size, in_features, grid_size + spline_order)
+        A = rearrange(A, 'b f g -> f b g')  # (in_features, batch_size, grid_size + spline_order)
+        B = rearrange(y, 'b f o -> f b o')  # (in_features, batch_size, out_features)
+    
+        solution = torch.linalg.lstsq(A, B).solution  # (in_features, grid_size + spline_order, out_features)
+    
+        result = rearrange(solution, 'f g o -> o f g')  # (out_features, in_features, grid_size + spline_order)
 
         assert result.size() == (
             self.out_features,
@@ -111,13 +135,16 @@ class KANLinear(torch.nn.Module):
         )
         return result.contiguous()
 
-    @property
-    def scaled_spline_weight(self) -> torch.Tensor:
-        if self.enable_standalone_scale_spline:
-            return self.spline_weight * self.spline_scaler.unsqueeze(-1)
-        return self.spline_weight
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    @property
+    def scaled_spline_weight(self):
+        return self.spline_weight * (
+            self.spline_scaler.unsqueeze(-1)
+            if self.enable_standalone_scale_spline
+            else 1.0
+        )
+
+    def forward(self, x: torch.Tensor):
         assert x.size(-1) == self.in_features
         original_shape = x.shape
         x = x.view(-1, self.in_features)
@@ -133,42 +160,64 @@ class KANLinear(torch.nn.Module):
         return output
 
     @torch.no_grad()
-    def update_grid(self, x: torch.Tensor, margin: float = 0.01):
-        assert x.dim() == 2 and x.size(1) == self.in_features, "Input tensor must be 2D with correct feature size."
-    
-        batch_size = x.size(0)
-    
-        splines = self.b_splines(x).permute(1, 0, 2)
-        orig_coeff = self.scaled_spline_weight.permute(1, 2, 0)
-        unreduced_spline_output = torch.bmm(splines, orig_coeff).permute(1, 0, 2)
+    def update_grid(self, x: torch.Tensor, margin=0.01):
+        assert x.dim() == 2 and x.size(1) == self.in_features
+        batch = x.size(0)
 
+        # Compute splines and permute dimensions
+        splines = self.b_splines(x)  # (batch, in, coeff)
+        splines = rearrange(splines, 'b in coeff -> in b coeff')
+
+        # Permute coefficient dimensions
+        orig_coeff = self.scaled_spline_weight  # (out, in, coeff)
+        orig_coeff = rearrange(orig_coeff, 'out in coeff -> in coeff out')
+
+        # Compute unreduced spline output
+        unreduced_spline_output = torch.einsum('ibc, ico -> ibo', splines, orig_coeff)
+
+        # Sort and calculate grid
         x_sorted = torch.sort(x, dim=0)[0]
-        indices = torch.linspace(0, batch_size - 1, self.grid_size + 1, dtype=torch.int64, device=x.device)
+        indices = torch.linspace(0, batch - 1, self.grid_size + 1, dtype=torch.int64, device=x.device)
         grid_adaptive = x_sorted[indices]
-    
+
         uniform_step = (x_sorted[-1] - x_sorted[0] + 2 * margin) / self.grid_size
-        grid_uniform = (
-            torch.arange(self.grid_size + 1, dtype=torch.float32, device=x.device).unsqueeze(1)
-            * uniform_step
-            + x_sorted[0]
-            - margin
-        )
-    
+        grid_uniform = repeat(torch.arange(self.grid_size + 1, dtype=torch.float32, device=x.device), 'g -> g 1')
+        grid_uniform = grid_uniform * uniform_step + x_sorted[0] - margin
+
         grid = self.grid_eps * grid_uniform + (1 - self.grid_eps) * grid_adaptive
-    
-        lower_bound = grid[:1] - uniform_step * torch.arange(self.spline_order, 0, -1, device=x.device).unsqueeze(1)
-        upper_bound = grid[-1:] + uniform_step * torch.arange(1, self.spline_order + 1, device=x.device).unsqueeze(1)
-        grid = torch.cat([lower_bound, grid, upper_bound], dim=0)
-    
-        # Update grid and spline weights in the class
-        self.grid.copy_(grid.T)
+        spline_order_range = torch.arange(self.spline_order, 0, -1, device=x.device)
+        grid = torch.cat([
+            grid[:1] - uniform_step * repeat(spline_order_range, 'o -> o 1'),
+            grid,
+            grid[-1:] + uniform_step * repeat(torch.arange(1, self.spline_order + 1, device=x.device), 'o -> o 1')
+        ], dim=0)
+
+        self.grid.copy_(rearrange(grid, 'g 1 -> 1 g'))
         self.spline_weight.data.copy_(self.curve2coeff(x, unreduced_spline_output))
 
-    def regularization_loss(self, regularize_activation: float = 1.0, regularize_entropy: float = 1.0) -> torch.Tensor:
-        l1_fake = self.spline_weight.abs().mean(-1)
+
+    def regularization_loss(self, regularize_activation=1.0, regularize_entropy=1.0):
+        """
+        Compute the regularization loss.
+
+        This is a dumb simulation of the original L1 regularization as stated in the
+        paper, since the original one requires computing absolutes and entropy from the
+        expanded (batch, in_features, out_features) intermediate tensor, which is hidden
+        behind the F.linear function if we want an memory efficient implementation.
+
+        The L1 regularization is now computed as mean absolute value of the spline
+        weights. The authors implementation also includes this term in addition to the
+        sample-based regularization.
+        """
+        # Compute L1 regularization term using einops
+        l1_fake = reduce(self.spline_weight, '... -> ...', 'abs').mean(-1)
         regularization_loss_activation = l1_fake.sum()
+
+        # Compute entropy regularization term
         p = l1_fake / regularization_loss_activation
         regularization_loss_entropy = -torch.sum(p * p.log())
+
+        # Combine the regularization terms
         return (
             regularize_activation * regularization_loss_activation
             + regularize_entropy * regularization_loss_entropy
@@ -178,44 +227,47 @@ class KANLinear(torch.nn.Module):
 class KAN(torch.nn.Module):
     def __init__(
         self,
-        layers_hidden: list,
-        grid_size: int = 5,
-        spline_order: int = 3,
-        scale_noise: float = 0.1,
-        scale_base: float = 1.0,
-        scale_spline: float = 1.0,
-        base_activation: torch.nn.Module = torch.nn.SiLU,
-        grid_eps: float = 0.02,
-        grid_range: list = [-1, 1],
+        layers_hidden,
+        grid_size=5,
+        spline_order=3,
+        scale_noise=0.1,
+        scale_base=1.0,
+        scale_spline=1.0,
+        base_activation=torch.nn.SiLU,
+        grid_eps=0.02,
+        grid_range=[-1, 1],
     ):
-        super().__init__()
+        super(KAN, self).__init__()
         self.grid_size = grid_size
         self.spline_order = spline_order
 
-        self.layers = torch.nn.ModuleList([
-            KANLinear(
-                in_features, out_features,
-                grid_size=grid_size,
-                spline_order=spline_order,
-                scale_noise=scale_noise,
-                scale_base=scale_base,
-                scale_spline=scale_spline,
-                base_activation=base_activation,
-                grid_eps=grid_eps,
-                grid_range=grid_range,
+        self.layers = torch.nn.ModuleList()
+        for in_features, out_features in zip(layers_hidden, layers_hidden[1:]):
+            self.layers.append(
+                KANLinear(
+                    in_features,
+                    out_features,
+                    grid_size=grid_size,
+                    spline_order=spline_order,
+                    scale_noise=scale_noise,
+                    scale_base=scale_base,
+                    scale_spline=scale_spline,
+                    base_activation=base_activation,
+                    grid_eps=grid_eps,
+                    grid_range=grid_range,
+                )
             )
-            for in_features, out_features in zip(layers_hidden, layers_hidden[1:])
-        ])
 
-    def forward(self, x: torch.Tensor, update_grid: bool = False) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, update_grid=False):
         for layer in self.layers:
             if update_grid:
                 layer.update_grid(x)
             x = layer(x)
         return x
 
-    def regularization_loss(self, regularize_activation: float = 1.0, regularize_entropy: float = 1.0) -> torch.Tensor:
+    def regularization_loss(self, regularize_activation=1.0, regularize_entropy=1.0):
         return sum(
             layer.regularization_loss(regularize_activation, regularize_entropy)
             for layer in self.layers
         )
+    

--- a/src/efficient_kan/kan.py
+++ b/src/efficient_kan/kan.py
@@ -186,7 +186,6 @@ class KANLinear(torch.nn.Module):
         self.grid.copy_(rearrange(grid, 'g 1 -> 1 g'))
         self.spline_weight.data.copy_(self.curve2coeff(x, unreduced_spline_output))
 
-
     def regularization_loss(self, regularize_activation=1.0, regularize_entropy=1.0):
         """
         Compute the regularization loss.


### PR DESCRIPTION
In certain areas, I thought the code would benefit from using Einops instead of standard PyTorch operations.